### PR TITLE
feat(chat): 重构流式传输功能并优化移动端布局

### DIFF
--- a/chat/src/components/chat/ChatModelDomain.vue
+++ b/chat/src/components/chat/ChatModelDomain.vue
@@ -183,6 +183,15 @@
           <TFormItem label="标签配置">
             <TInput v-model="mobileTagsValue" placeholder="多个标签用逗号分隔" />
           </TFormItem>
+          <TFormItem label="流式传输">
+            <TButton
+              variant="outline"
+              :theme="mobileDraftStreamEnabled ? 'primary' : 'default'"
+              @click="$emit('toggle-mobile-model-stream')"
+            >
+              {{ mobileDraftStreamEnabled ? '已开启' : '已关闭' }}
+            </TButton>
+          </TFormItem>
         </div>
       </TForm>
       <div class="mobile-overlay-actions drawer-actions">
@@ -374,6 +383,15 @@
           <TFormItem class="form-grid-span-2" label="标签配置">
             <TInput v-model="desktopTagsValue" placeholder="多个标签用逗号分隔" />
           </TFormItem>
+          <TFormItem label="流式传输">
+            <TButton
+              variant="outline"
+              :theme="desktopDraftStreamEnabled ? 'primary' : 'default'"
+              @click="$emit('toggle-desktop-model-stream')"
+            >
+              {{ desktopDraftStreamEnabled ? '已开启' : '已关闭' }}
+            </TButton>
+          </TFormItem>
         </div>
       </TForm>
       <div class="mobile-overlay-actions drawer-actions">
@@ -496,6 +514,14 @@ const props = defineProps({
     type: Boolean,
     required: true,
   },
+  mobileDraftStreamEnabled: {
+    type: Boolean,
+    required: true,
+  },
+  desktopDraftStreamEnabled: {
+    type: Boolean,
+    required: true,
+  },
 })
 
 const emit = defineEmits<{
@@ -517,6 +543,8 @@ const emit = defineEmits<{
   (e: 'handle-desktop-model-card-action', modelId: string, action?: CardAction): void
   (e: 'save-mobile-model'): void
   (e: 'save-desktop-model'): void
+  (e: 'toggle-mobile-model-stream'): void
+  (e: 'toggle-desktop-model-stream'): void
 }>()
 
 const mobileTagsValue = computed({

--- a/chat/src/hooks/chat-view/useChatModelManager.ts
+++ b/chat/src/hooks/chat-view/useChatModelManager.ts
@@ -2,12 +2,7 @@ import { MessagePlugin } from 'tdesign-vue-next'
 import { computed, reactive, ref, watch } from 'vue'
 
 import { getCapabilities, saveModelConfigs, testModelConnection } from '@/lib/api'
-import type {
-  AIModelConfigItem,
-  ModelCapabilities,
-  ModelOption,
-  ProviderType,
-} from '@/types/ai'
+import type { AIModelConfigItem, ModelCapabilities, ModelOption, ProviderType } from '@/types/ai'
 
 interface UseChatModelManagerOptions {
   createModelConfig: (provider?: ProviderType, index?: number) => AIModelConfigItem
@@ -34,6 +29,7 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
   const activeModelConfigId = ref('')
 
   const streamEnabled = ref(true)
+  const streamEnabledByModelId = ref<Record<string, boolean>>({})
   const thinkingEnabled = ref(false)
   const capabilities = ref<ModelCapabilities>({
     supportsStreaming: true,
@@ -85,13 +81,16 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
       desktopModelDraft.temperature = typeof value === 'number' ? value : null
     },
   })
+  const mobileDraftStreamEnabled = computed(
+    () => streamEnabledByModelId.value[mobileModelDraft.id] ?? true,
+  )
+  const desktopDraftStreamEnabled = computed(
+    () => streamEnabledByModelId.value[desktopModelDraft.id] ?? true,
+  )
 
   watch(
     capabilities,
     (value) => {
-      if (!value.supportsStreaming) {
-        streamEnabled.value = false
-      }
       if (!value.supportsReasoning) {
         thinkingEnabled.value = false
       }
@@ -125,13 +124,19 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
   }
 
   function applyModelConfigs(configs: AIModelConfigItem[], activeId: string) {
-    const normalized = (configs.length ? configs : [options.createModelConfig()]).map((item, index) => ({
-      ...item,
-      name: String(item.name || `模型配置 ${index + 1}`),
-      description: String(item.description || '').trim(),
-      tags: options.normalizeModelTags(item.tags),
-    }))
+    const normalized = (configs.length ? configs : [options.createModelConfig()]).map(
+      (item, index) => ({
+        ...item,
+        name: String(item.name || `模型配置 ${index + 1}`),
+        description: String(item.description || '').trim(),
+        tags: options.normalizeModelTags(item.tags),
+      }),
+    )
     modelConfigs.value = normalized
+    streamEnabledByModelId.value = normalized.reduce<Record<string, boolean>>((acc, item) => {
+      acc[item.id] = streamEnabledByModelId.value[item.id] ?? true
+      return acc
+    }, {})
     activeModelConfigId.value = normalized.some((item) => item.id === activeId)
       ? activeId
       : normalized[0]!.id
@@ -140,6 +145,28 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     editingConfigId.value = editingTarget.id
     syncEditingConfig(editingTarget)
   }
+
+  watch(
+    activeModelConfigId,
+    (value) => {
+      if (!value) {
+        return
+      }
+      streamEnabled.value = streamEnabledByModelId.value[value] ?? true
+    },
+    { immediate: true },
+  )
+
+  watch(streamEnabled, (value) => {
+    const currentId = activeModelConfigId.value
+    if (!currentId) {
+      return
+    }
+    streamEnabledByModelId.value = {
+      ...streamEnabledByModelId.value,
+      [currentId]: value,
+    }
+  })
 
   async function loadCapabilities() {
     const current = activeModelConfig.value
@@ -293,6 +320,29 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     configVisible.value = false
   }
 
+  function setModelStreamEnabled(modelId: string, value: boolean) {
+    if (!modelId) {
+      return
+    }
+    streamEnabledByModelId.value = {
+      ...streamEnabledByModelId.value,
+      [modelId]: value,
+    }
+    if (activeModelConfigId.value === modelId) {
+      streamEnabled.value = value
+    }
+  }
+
+  function toggleMobileDraftStreamEnabled() {
+    const modelId = mobileModelDraft.id
+    setModelStreamEnabled(modelId, !mobileDraftStreamEnabled.value)
+  }
+
+  function toggleDesktopDraftStreamEnabled() {
+    const modelId = desktopModelDraft.id
+    setModelStreamEnabled(modelId, !desktopDraftStreamEnabled.value)
+  }
+
   function openConfigDialog() {
     if (!modelConfigs.value.length) {
       addModelConfig()
@@ -339,7 +389,7 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     }
   }
 
-  function handleProviderChange(_value: unknown) {
+  function handleProviderChange() {
     const nextProvider: ProviderType = 'openai'
     const defaults = options.defaultModelConfigs[nextProvider]
     editingConfig.provider = nextProvider
@@ -402,7 +452,7 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     }
   }
 
-  function handleMobileModelProviderChange(_value: unknown) {
+  function handleMobileModelProviderChange() {
     const nextProvider: ProviderType = 'openai'
     const defaults = options.defaultModelConfigs[nextProvider]
     mobileModelDraft.provider = nextProvider
@@ -416,7 +466,7 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     }
   }
 
-  function handleDesktopModelProviderChange(_value: unknown) {
+  function handleDesktopModelProviderChange() {
     const nextProvider: ProviderType = 'openai'
     const defaults = options.defaultModelConfigs[nextProvider]
     desktopModelDraft.provider = nextProvider
@@ -527,7 +577,9 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
       }
       const nextConfigs =
         mobileModelEditorMode.value === 'edit'
-          ? modelConfigs.value.map((item) => (item.id === editingMobileModelId.value ? nextConfig : item))
+          ? modelConfigs.value.map((item) =>
+              item.id === editingMobileModelId.value ? nextConfig : item,
+            )
           : [...modelConfigs.value, nextConfig]
 
       await persistModelConfigs(
@@ -548,7 +600,9 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     try {
       const nextConfigs = modelConfigs.value.filter((item) => item.id !== configId)
       const nextActiveModelId =
-        activeModelConfigId.value === configId ? nextConfigs[0]?.id || options.createModelConfig().id : activeModelConfigId.value
+        activeModelConfigId.value === configId
+          ? nextConfigs[0]?.id || options.createModelConfig().id
+          : activeModelConfigId.value
       await persistModelConfigs(nextConfigs, nextActiveModelId, '模型配置已删除')
     } catch (error) {
       MessagePlugin.error(error instanceof Error ? error.message : '删除模型配置失败')
@@ -664,6 +718,10 @@ export function useChatModelManager(options: UseChatModelManagerOptions) {
     showThinkingToggle,
     effectiveStream,
     effectiveThinking,
+    mobileDraftStreamEnabled,
+    desktopDraftStreamEnabled,
+    toggleMobileDraftStreamEnabled,
+    toggleDesktopDraftStreamEnabled,
     editingModelOptions,
     temperatureValue,
     mobileModelTemperatureValue,

--- a/chat/src/hooks/chat-view/useChatViewUiController.ts
+++ b/chat/src/hooks/chat-view/useChatViewUiController.ts
@@ -8,9 +8,7 @@ interface UseChatViewUiControllerOptions {
   robotTemplates: Ref<AIRobotCard[]>
   selectedNewChatRobotId: Ref<string>
   selectedNewChatRobot: ComputedRef<AIRobotCard | null>
-  showStreamToggle: ComputedRef<boolean>
   showThinkingToggle: ComputedRef<boolean>
-  streamEnabled: Ref<boolean>
   thinkingEnabled: Ref<boolean>
   onCreateNewChat: (robot?: AIRobotCard | null) => Promise<void>
   onOpenAgentManageDialog: () => void
@@ -53,12 +51,6 @@ export function useChatViewUiController(options: UseChatViewUiControllerOptions)
     options.onOpenAgentManageDialog()
   }
 
-  function switchStream() {
-    if (options.showStreamToggle.value) {
-      options.streamEnabled.value = !options.streamEnabled.value
-    }
-  }
-
   function switchThinking() {
     if (options.showThinkingToggle.value) {
       options.thinkingEnabled.value = !options.thinkingEnabled.value
@@ -91,7 +83,6 @@ export function useChatViewUiController(options: UseChatViewUiControllerOptions)
     confirmStartNewChat,
     handleNewChatEntry,
     handleGoToRobotPage,
-    switchStream,
     switchThinking,
     openHistorySession,
     handleDeleteSession,

--- a/chat/src/views/ChatView.css
+++ b/chat/src/views/ChatView.css
@@ -843,6 +843,10 @@
 @media (max-width: 900px) {
   .sender-footer-actions {
     width: 100%;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 }
 
@@ -939,8 +943,12 @@
   }
 
   .sender-footer-actions {
+    flex-wrap: nowrap;
+    flex-direction: row;
     align-items: stretch;
     justify-content: flex-start;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 
   .sender-footer-actions .t-button {

--- a/chat/src/views/ChatView.vue
+++ b/chat/src/views/ChatView.vue
@@ -143,18 +143,6 @@
             <template #sender-footer-prefix>
               <TSpace align="center" size="small" class="sender-footer-actions">
                 <TButton
-                  v-if="showStreamToggle"
-                  shape="round"
-                  variant="outline"
-                  :theme="effectiveStream ? 'primary' : 'default'"
-                  @click="switchStream"
-                >
-                  <template #icon>
-                    <OrderIcon />
-                  </template>
-                  <span class="footer-button-label">流式传输</span>
-                </TButton>
-                <TButton
                   v-if="showThinkingToggle"
                   shape="round"
                   variant="outline"
@@ -249,6 +237,8 @@
     :saving-mobile-model="savingMobileModel"
     :saving-desktop-model="savingDesktopModel"
     :loading-models="loadingModels"
+    :mobile-draft-stream-enabled="mobileDraftStreamEnabled"
+    :desktop-draft-stream-enabled="desktopDraftStreamEnabled"
     @update:mobile-model-tags-input="(value) => (mobileModelTagsInput = value)"
     @update:desktop-model-tags-input="(value) => (desktopModelTagsInput = value)"
     @update:mobile-model-temperature-value="(value) => (mobileModelTemperatureValue = value)"
@@ -264,6 +254,8 @@
     @handle-desktop-model-card-action="handleDesktopModelCardAction"
     @save-mobile-model="saveMobileModel"
     @save-desktop-model="saveDesktopModel"
+    @toggle-mobile-model-stream="toggleMobileDraftStreamEnabled"
+    @toggle-desktop-model-stream="toggleDesktopDraftStreamEnabled"
   />
 
   <ChatSessionDomain
@@ -297,12 +289,7 @@ import {
   Select as TSelect,
   Space as TSpace,
 } from 'tdesign-vue-next'
-import {
-  LightbulbIcon,
-  MenuIcon,
-  OrderIcon,
-  SettingIcon,
-} from 'tdesign-icons-vue-next'
+import { LightbulbIcon, MenuIcon, SettingIcon } from 'tdesign-icons-vue-next'
 
 import ChatAgentPanels from '@/components/chat/ChatAgentPanels.vue'
 import ChatModelDomain from '@/components/chat/ChatModelDomain.vue'
@@ -408,7 +395,6 @@ const {
   mobileModelEditorMode,
   desktopModelEditorMode,
   activeModelConfigId,
-  streamEnabled,
   thinkingEnabled,
   modelConfigs,
   modelOptionsMap,
@@ -418,10 +404,13 @@ const {
   desktopModelTagsInput,
   activeModelConfig,
   currentModelLabel,
-  showStreamToggle,
   showThinkingToggle,
   effectiveStream,
   effectiveThinking,
+  mobileDraftStreamEnabled,
+  desktopDraftStreamEnabled,
+  toggleMobileDraftStreamEnabled,
+  toggleDesktopDraftStreamEnabled,
   mobileModelTemperatureValue,
   desktopModelTemperatureValue,
   applyModelConfigs,
@@ -561,7 +550,6 @@ const {
   confirmStartNewChat,
   handleNewChatEntry,
   handleGoToRobotPage,
-  switchStream,
   switchThinking,
   openHistorySession,
   handleDeleteSession,
@@ -571,9 +559,7 @@ const {
   robotTemplates,
   selectedNewChatRobotId,
   selectedNewChatRobot,
-  showStreamToggle,
   showThinkingToggle,
-  streamEnabled,
   thinkingEnabled,
   onCreateNewChat: createNewChat,
   onOpenAgentManageDialog: openAgentManageDialog,


### PR DESCRIPTION
重构流式传输功能，改为按模型ID独立配置状态
移除全局流式传输开关，在模型配置中单独控制
优化移动端发送按钮区域的布局和滚动行为