### PR TITLE
refactor(chat): 重构窗口大小处理逻辑并使用新的useWindowSize钩子

### DIFF
--- a/chat/src/hooks/chat-view/useChatViewBootstrap.ts
+++ b/chat/src/hooks/chat-view/useChatViewBootstrap.ts
@@ -1,4 +1,4 @@
-import { onMounted, onUnmounted, watch, type Ref } from 'vue'
+import { onMounted, watch, type Ref } from 'vue'
 
 interface UseChatViewBootstrapOptions {
   activePrimaryTab: Ref<'agent' | 'discover' | 'mine'>
@@ -6,15 +6,12 @@ interface UseChatViewBootstrapOptions {
   isSignedIn: Ref<boolean | undefined>
   hasInitializedAgent: Ref<boolean>
   ensureAgentInitialized: () => Promise<void>
-  syncViewportMode: () => void
   initDebug: (message: string, extra?: Record<string, unknown>) => void
   routeName: () => string
 }
 
 export function useChatViewBootstrap(options: UseChatViewBootstrapOptions) {
   onMounted(async () => {
-    options.syncViewportMode()
-    window.addEventListener('resize', options.syncViewportMode)
     options.initDebug('onMounted')
     await options.ensureAgentInitialized()
   })
@@ -61,10 +58,4 @@ export function useChatViewBootstrap(options: UseChatViewBootstrapOptions) {
     { immediate: true },
   )
 
-  onUnmounted(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    window.removeEventListener('resize', options.syncViewportMode)
-  })
 }

--- a/chat/src/hooks/chat-view/useChatViewUiController.ts
+++ b/chat/src/hooks/chat-view/useChatViewUiController.ts
@@ -1,7 +1,8 @@
 import { MessagePlugin } from 'tdesign-vue-next'
-import { ref, type ComputedRef, type Ref } from 'vue'
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
 
 import type { AIRobotCard } from '@/types/ai'
+import { useWindowSize } from '@/hooks/useWindowSize'
 
 interface UseChatViewUiControllerOptions {
   mobileBreakpoint: number
@@ -17,7 +18,8 @@ interface UseChatViewUiControllerOptions {
 }
 
 export function useChatViewUiController(options: UseChatViewUiControllerOptions) {
-  const isMobile = ref(false)
+  const { width } = useWindowSize()
+  const isMobile = computed(() => width.value <= options.mobileBreakpoint)
   const sidebarDrawerVisible = ref(false)
   const newChatVisible = ref(false)
 
@@ -68,13 +70,6 @@ export function useChatViewUiController(options: UseChatViewUiControllerOptions)
     await options.onDeleteSession(targetSessionId)
   }
 
-  function syncViewportMode() {
-    if (typeof window === 'undefined') {
-      return
-    }
-    isMobile.value = window.innerWidth <= options.mobileBreakpoint
-  }
-
   return {
     isMobile,
     sidebarDrawerVisible,
@@ -86,6 +81,5 @@ export function useChatViewUiController(options: UseChatViewUiControllerOptions)
     switchThinking,
     openHistorySession,
     handleDeleteSession,
-    syncViewportMode,
   }
 }

--- a/chat/src/hooks/useWindowSize.ts
+++ b/chat/src/hooks/useWindowSize.ts
@@ -1,0 +1,31 @@
+import { onMounted, onUnmounted, ref } from 'vue'
+
+export function useWindowSize() {
+  const width = ref(0)
+  const height = ref(0)
+
+  function updateWindowSize() {
+    if (typeof window === 'undefined') {
+      return
+    }
+    width.value = window.innerWidth
+    height.value = window.innerHeight
+  }
+
+  onMounted(() => {
+    updateWindowSize()
+    window.addEventListener('resize', updateWindowSize)
+  })
+
+  onUnmounted(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    window.removeEventListener('resize', updateWindowSize)
+  })
+
+  return {
+    width,
+    height,
+  }
+}

--- a/chat/src/views/ChatView.css
+++ b/chat/src/views/ChatView.css
@@ -1,5 +1,4 @@
 .main {
-  height: 100vh;
   background-color: #f5f5f5;
   display: flex;
   flex-direction: row;
@@ -361,7 +360,9 @@
 }
 
 @keyframes chat-loading-bounce {
-  0%, 80%, 100% {
+  0%,
+  80%,
+  100% {
     opacity: 0.35;
     transform: translateY(0) scale(0.9);
   }
@@ -554,7 +555,6 @@
   color: #9ca3af;
   cursor: pointer;
 }
-
 
 .agent-manage-layout {
   grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
@@ -862,8 +862,6 @@
   .chat-container {
     padding: 0 12px calc(68px + env(safe-area-inset-bottom));
   }
-
-
 
   .chatbot {
     max-width: none;

--- a/chat/src/views/ChatView.vue
+++ b/chat/src/views/ChatView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="main">
+  <div class="main" :style="mainStyle">
     <PrimaryNav v-model="activePrimaryTab" />
     <template v-if="activePrimaryTab === 'agent'">
       <div class="mess-list">
@@ -333,10 +333,16 @@ import {
 import type { ChatbotInstance } from '@/hooks/chat-view/useChatView.types'
 import { useChatSession } from '@/hooks/useChatSession'
 import { useTokenStatisticAnimation } from '@/hooks/useTokenStatisticAnimation'
+import { useWindowSize } from '@/hooks/useWindowSize'
 
 const router = useRouter()
 const route = useRoute()
 const MOBILE_BREAKPOINT = 768
+const { width: windowWidth, height: windowHeight } = useWindowSize()
+const mainStyle = computed(() => ({
+  width: windowWidth.value > 0 ? `${windowWidth.value}px` : '100vw',
+  height: windowHeight.value > 0 ? `${windowHeight.value}px` : '100vh',
+}))
 
 const providerOptions = PROVIDER_OPTIONS
 const {
@@ -553,7 +559,6 @@ const {
   switchThinking,
   openHistorySession,
   handleDeleteSession,
-  syncViewportMode,
 } = useChatViewUiController({
   mobileBreakpoint: MOBILE_BREAKPOINT,
   robotTemplates,
@@ -642,7 +647,6 @@ useChatViewBootstrap({
   isSignedIn,
   hasInitializedAgent,
   ensureAgentInitialized,
-  syncViewportMode,
   initDebug,
   routeName: () => String(route.name || ''),
 })

--- a/chat/vite.config.mjs
+++ b/chat/vite.config.mjs
@@ -5,10 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools()],
   server: {
     proxy: {
       '/api': {
@@ -16,6 +13,7 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+    host: '0.0.0.0',
   },
   resolve: {
     alias: {

--- a/chat/vite.config.ts
+++ b/chat/vite.config.ts
@@ -6,10 +6,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools()],
   server: {
     proxy: {
       '/api': {
@@ -17,10 +14,11 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+    host: '0.0.0.0',
   },
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
移除原有的syncViewportMode方法，改用新添加的useWindowSize钩子来处理窗口大小变化 调整ChatView布局样式，使用动态计算的高度和宽度
优化代码结构，移除不必要的监听器和重复逻辑